### PR TITLE
Fix GetLatestQuoteAsync

### DIFF
--- a/CoinMarketCap/CoinMarketcapClient.cs
+++ b/CoinMarketCap/CoinMarketcapClient.cs
@@ -125,15 +125,15 @@ namespace CoinMarketCap
         /// <summary>
         /// Get the latest market quote for 1 or more cryptocurrencies. Use the "convert" option to return market values in multiple fiat and cryptocurrency conversions in the same call.
         /// </summary>
-        public async Task<Response<CryptocurrencyWithLatestQuote>> GetLatestQuoteAsync(LatestQuoteParameters request, CancellationToken cancellationToken)
+        public async Task<Response<Dictionary<string,CryptocurrencyWithLatestQuote>>> GetLatestQuoteAsync(LatestQuoteParameters request, CancellationToken cancellationToken)
         {
-            return await SendApiRequest<CryptocurrencyWithLatestQuote>(request, "cryptocurrency/quotes/latest", cancellationToken);
+            return await SendApiRequest<Dictionary<string, CryptocurrencyWithLatestQuote>>(request, "cryptocurrency/quotes/latest", cancellationToken);
         }
 
         /// <summary>
         /// Get the latest market quote for 1 or more cryptocurrencies. Use the "convert" option to return market values in multiple fiat and cryptocurrency conversions in the same call.
         /// </summary>
-        public Response<CryptocurrencyWithLatestQuote> GetLatestQuote(LatestQuoteParameters request)
+        public Response<Dictionary<string, CryptocurrencyWithLatestQuote>> GetLatestQuote(LatestQuoteParameters request)
         {
             return GetLatestQuoteAsync(request, CancellationToken.None).Result;
         }

--- a/CoinMarketCap/Models/Cryptocurrency/IdMapParameters.cs
+++ b/CoinMarketCap/Models/Cryptocurrency/IdMapParameters.cs
@@ -15,5 +15,8 @@ namespace CoinMarketCap.Models.Cryptocurrency
 
         [JsonProperty("symbol")]
         public string Symbol { get; set; }
+
+        [JsonProperty("sort")]
+        public string Sort { get; set; }
     }
 }

--- a/CoinMarketCap/Models/Cryptocurrency/LatestQuoteParameters.cs
+++ b/CoinMarketCap/Models/Cryptocurrency/LatestQuoteParameters.cs
@@ -5,7 +5,7 @@ namespace CoinMarketCap.Models.Cryptocurrency
     public class LatestQuoteParameters
     {
         [JsonProperty("id")]
-        public long Id { get; set; }
+        public string Id { get; set; }
 
         [JsonProperty("symbol")]
         public string Symbol { get; set; }


### PR DESCRIPTION
Fix GetLatestQuoteAsync : the cryptocurrency/quotes/latest endpoint returns a dictionary of quotes
Fix GetLatestQuoteAsync : the Id parameter support a list of identifiers
Improve GetCryptocurrencyIdMapAsync  : add sort parameter
