### PR TITLE
Change LatestQuoteParameters to accept mulltiple ids or symbols

### DIFF
--- a/CoinMarketCap/CoinMarketCap.csproj
+++ b/CoinMarketCap/CoinMarketCap.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
 </Project>

--- a/CoinMarketCap/CoinMarketcapClient.cs
+++ b/CoinMarketCap/CoinMarketcapClient.cs
@@ -212,8 +212,8 @@ namespace CoinMarketCap
                     Name = GetPropName(x),
                     Value = x.GetValue(parameters)
                 })
-                .Where(x => x.Value != null)
-                .Select(x => $"{x.Name}={System.Net.WebUtility.UrlEncode(x.Value.ToString())}")
+                .Where(x => x.Value != null && !string.IsNullOrWhiteSpace(x.Name))
+                .Select(x => $"{x.Name}={WebUtility.UrlEncode(x.Value.ToString())}")
                 // prepend ? for the first param, & for the rest
                 .Select((x, i) => i > 0 ? $"&{x}" : $"?{x}");
 

--- a/CoinMarketCap/Models/Cryptocurrency/LatestQuoteParameters.cs
+++ b/CoinMarketCap/Models/Cryptocurrency/LatestQuoteParameters.cs
@@ -1,14 +1,36 @@
-﻿using Newtonsoft.Json;
+﻿using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
 
 namespace CoinMarketCap.Models.Cryptocurrency
 {
     public class LatestQuoteParameters
     {
+        public int? Id { get; set; }
+
+        public List<int> Ids { get; } = new List<int>();
+
         [JsonProperty("id")]
-        public int Id { get; set; }
+        internal string FlattenedIds {
+	        get {
+		        if(Id.HasValue)
+			        return Id.ToString();
+		        return Ids.Any() ? string.Join(",", Ids) : null;
+	        }
+        }
+
+        public string Symbol { get; set; }
+
+        public List<string> Symbols { get; } = new List<string>();
 
         [JsonProperty("symbol")]
-        public string Symbol { get; set; }
+        internal string FlattenedSymbols {
+	        get {
+		        if(!string.IsNullOrWhiteSpace(Symbol))
+			        return Symbol;
+                return Symbols.Any() ? string.Join(",", Symbols) : null;
+	        }
+        }
 
         [JsonProperty("convert")]
         public string Convert { get; set; }


### PR DESCRIPTION
1.  Make Id nullable so that if symbol is set, both aren't sent (which fails)
2. Adjust to allow multiple Ids or multiple Symbols to be selected
3. Change client to ignore properties without the JsonProperty attribute