### PR TITLE
TryFix Not getting quotes

### DIFF
--- a/CoinMarketCap.Tests/CoinMarketCap.Tests.csproj
+++ b/CoinMarketCap.Tests/CoinMarketCap.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="..\packages\MSTest.TestAdapter.2.2.3\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.2.2.3\build\net45\MSTest.TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -40,13 +40,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.2.1.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <HintPath>..\packages\MSTest.TestFramework.2.2.3\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.2.1.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <HintPath>..\packages\MSTest.TestFramework.2.2.3\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -80,8 +80,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.2.3\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.2.3\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.2.3\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.2.3\build\net45\MSTest.TestAdapter.targets'))" />
   </Target>
-  <Import Project="..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.targets')" />
+  <Import Project="..\packages\MSTest.TestAdapter.2.2.3\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.2.2.3\build\net45\MSTest.TestAdapter.targets')" />
 </Project>

--- a/CoinMarketCap.Tests/CoinMarketCapClientTests.cs
+++ b/CoinMarketCap.Tests/CoinMarketCapClientTests.cs
@@ -10,7 +10,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace CoinMarketCap.Tests
 {
-    [Ignore]
     [TestClass]
     public class CoinMarketCapClientTests
     {

--- a/CoinMarketCap.Tests/packages.config
+++ b/CoinMarketCap.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MSTest.TestAdapter" version="2.1.2" targetFramework="net461" />
-  <package id="MSTest.TestFramework" version="2.1.2" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net461" />
+  <package id="MSTest.TestAdapter" version="2.2.3" targetFramework="net461" />
+  <package id="MSTest.TestFramework" version="2.2.3" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
 </packages>

--- a/CoinMarketCap/Models/Cryptocurrency/CryptocurrencyPriceQuote.cs
+++ b/CoinMarketCap/Models/Cryptocurrency/CryptocurrencyPriceQuote.cs
@@ -20,6 +20,15 @@ namespace CoinMarketCap.Models.Cryptocurrency
         [JsonProperty("percent_change_7d")]
         public double? PercentChange7D { get; set; }
 
+        [JsonProperty("percent_change_30d")]
+        public double? PercentChange30D { get; set; }
+
+        [JsonProperty("percent_change_60d")]
+        public double? PercentChange60D { get; set; }
+
+        [JsonProperty("percent_change_90d")]
+        public double? PercentChange90D { get; set; }
+
         [JsonProperty("market_cap")]
         public long? MarketCap { get; set; }
 


### PR DESCRIPTION
While trying to fix #6  I enabled the tests and bump some packages. 

I can confirm that the test for `GetLatestQuote`  works fine in tests. 
However, consuming this package from a `net6`  aspnetcore WASM, and calling `GetLatestQuote`  does not deserialize the `CryptocurrencyPriceQuote `object. 

Perhaps this is `System.text.Json`  behaviour? In any case I've added some of the new properties to the response.