### PR TITLE
Add Dispose method

### DIFF
--- a/CoinMarketCap/CoinMarketcapClient.cs
+++ b/CoinMarketCap/CoinMarketcapClient.cs
@@ -14,9 +14,17 @@ using Newtonsoft.Json;
 
 namespace CoinMarketCap
 {
-    public class CoinMarketCapClient
+    public class CoinMarketCapClient : IDisposable
     {
-        public readonly HttpClient HttpClient = new HttpClient
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing,
+        /// releasing, or resetting unmanaged resources.
+        /// </summary>
+        /// <filterpriority>2</filterpriority>
+        public void Dispose()
+            => HttpClient?.Dispose();
+
+        public HttpClient HttpClient { get; } = new HttpClient
         {
             BaseAddress = new Uri("https://pro-api.coinmarketcap.com/v1/")
         };


### PR DESCRIPTION
Added a `Dispose` method to the `CoinMarketCapClient` class.  The `HttpClient` needs to be able to free unmanaged system resources at the time it ceases operation.  Might not make a difference for casual use, but I am implementing an algorithmic trading bot and I forsee there being issues with memory usage if I can't dispose the client.